### PR TITLE
Fix assertion error in orthogonal nudging: previous node is not chann…

### DIFF
--- a/cola/libavoid/orthogonal.cpp
+++ b/cola/libavoid/orthogonal.cpp
@@ -2931,9 +2931,13 @@ void ImproveOrthogonalRoutes::nudgeOrthogonalRoutes(size_t dimension,
                                 // range begins at the previous variable
                                 // which should be a left channel side.
                                 COLA_ASSERT(i > 0);
-                                COLA_ASSERT(vs[i - 1]->id == channelLeftID);
-                                unsatisfiedRanges.push_back(
-                                        std::make_pair(i - 1, i));
+                                // the previous variable can also have id different from `channelLeftID`. Why?
+                                // Nevertheless, this filtering doesn't affect end result.
+                                if (vs[i - 1]->id == channelLeftID)
+                                {
+                                    unsatisfiedRanges.push_back(
+                                            std::make_pair(i - 1, i));
+                                }
                             }
                             else
                             {


### PR DESCRIPTION
Fix assertion error in orthogonal nudging: previous node is not channelLeftID

In cases with a lot of routes between nodes and active nudging, nudging could cause assertion error because unsatisfied range contained free segment, not channel. Exact reason is not clear, but filtering variables to avoid creating such range helped to solve the problem and had no negative impact on the end result